### PR TITLE
State splitting refactor

### DIFF
--- a/src/entities.rs
+++ b/src/entities.rs
@@ -17,8 +17,8 @@ pub struct WalkingProgress {
 #[derive(Clone, Copy)]
 pub struct Creep {
     pub pos: FloatPosition,
-    pub health: u32,
-    pub max_health: u32,
+    pub health: f32,
+    pub max_health: f32,
     pub walking: WalkingProgress,
     pub speed: u32, // no. of ticks to walk one grid cell, lower is faster
 }
@@ -104,6 +104,7 @@ pub fn update_basic_turret(turret: &mut Turret, specific: &mut BasicData, state:
         state.particles.add(Particle {
             pos: turret_pos,
             target: target_creep_item.item_ref.clone(),
+            damage: turret_data.damage * turret_data.damage_multiplier / 100.0,
         });
     }
 }
@@ -123,4 +124,5 @@ pub struct Particle {
     // todo: remove "pub". should not leave api. this reference should not be needed for drawing. passing references
     // through api seems odd / hard to do in rust?
     pub target: RecycledListRef,
+    pub damage: f32,
 }

--- a/src/entities.rs
+++ b/src/entities.rs
@@ -107,8 +107,8 @@ pub fn update_basic_tower(turret: &mut Turret, specific: &mut BasicData, state: 
 
     specific.rotation = dy.atan2(dx);
 
-    // if can shoot, shoot
-    if state.tick > turret.general_data.last_shot + 60 {
+    // if ready for shooting, shoot
+    if state.tick > turret.general_data.last_shot + (60.0 / turret_data.attack_speed) as u32 {
         turret.general_data.last_shot = state.tick;
         state.particles.add(Particle {
             pos: turret_pos,

--- a/src/external.rs
+++ b/src/external.rs
@@ -1,6 +1,7 @@
 use crate::entities::{Creep, Particle};
 use crate::recycled_list::RecycledListRef;
-use crate::utils::FloatPosition;
+use crate::utils::{to_float_position, FloatPosition};
+use crate::{SpecificData, State, Turret};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -8,6 +9,15 @@ use wasm_bindgen::prelude::*;
 pub struct ExternalTurret {
     pub pos: FloatPosition,
     pub rotation: f32, // orientation/angle in RAD
+}
+
+pub fn to_external_turret(turret: &Turret, state: &State) -> ExternalTurret {
+    ExternalTurret {
+        pos: to_float_position(turret.general_data.pos, state.cell_length),
+        rotation: match &turret.specific_data {
+            SpecificData::Basic(d) => d.rotation,
+        },
+    }
 }
 
 #[wasm_bindgen]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,7 +160,6 @@ impl Game {
                 pos: grid_pos,
                 last_shot: self.state.tick,
                 level: 0,
-                kind: TurretKind::Basic,
             },
             specific_data: SpecificData::Basic(BasicData { rotation: 0.0 }),
         });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,7 +161,10 @@ impl Game {
                 last_shot: self.state.tick,
                 level: 0,
             },
-            specific_data: SpecificData::Basic(BasicData { rotation: 0.0 }),
+            specific_data: SpecificData::Basic(BasicData {
+                rotation: 0.0,
+                target: RecycledListRef::null_ref(),
+            }),
         });
 
         match compute_creep_paths(self) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,7 +210,7 @@ impl Game {
             _ => (),
         }
 
-        if (self.state.tick - self.state.last_spawn > 60) && (self.state.unspawned_creeps > 0) {
+        if (self.state.tick - self.state.last_spawn > 120) && (self.state.unspawned_creeps > 0) {
             self.state.last_spawn = self.state.tick;
             self.state.unspawned_creeps -= 1;
             self.state.creeps.add(Creep {
@@ -221,7 +221,7 @@ impl Game {
                     current_goal: 0,
                     steps_taken: 0,
                 },
-                speed: 10,
+                speed: 60,
             });
         }
 
@@ -295,8 +295,8 @@ impl Game {
             } else {
                 let dx = target_creep.pos.x - particle.pos.x;
                 let dy = target_creep.pos.y - particle.pos.y;
-                particle.pos.x += (dx / d) * 5.0;
-                particle.pos.y += (dy / d) * 5.0;
+                particle.pos.x += (dx / d) * particle.speed;
+                particle.pos.y += (dy / d) * particle.speed;
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ mod recycled_list;
 mod utils;
 
 use entities::*;
-use external::{ExternalState, ExternalTurret, GameResult, TurretRef};
+use external::{to_external_turret, ExternalState, ExternalTurret, GameResult, TurretRef};
 use path::find_path;
 use recycled_list::{RecycledList, RecycledListRef};
 use utils::{
@@ -110,13 +110,7 @@ impl Game {
             turrets: state
                 .turrets
                 .iter()
-                .map(|x| ExternalTurret {
-                    pos: to_float_position(x.general_data.pos, state.cell_length),
-                    rotation: match &x.specific_data {
-                        SpecificData::Basic(d) => d.rotation,
-                        _ => 0.0,
-                    },
-                })
+                .map(|x| to_external_turret(x, state))
                 .collect(),
             particles: state.particles.iter().map(|x| *x).collect(),
             creeps: state.creeps.iter().map(|x| *x).collect(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,8 +68,8 @@ impl Game {
             creep_goals: vec![GridPosition { x: 10, y: 5 }, GridPosition { x: 19, y: 9 }],
             creep_path: vec![],
             last_spawn: 0,
-            unspawned_creeps: 3,
-            creep_count_per_level: 3,
+            unspawned_creeps: 10,
+            creep_count_per_level: 10,
             creeps: RecycledList::new(),
             particles: RecycledList::new(),
             cell_length: 30.0,
@@ -215,8 +215,8 @@ impl Game {
             self.state.unspawned_creeps -= 1;
             self.state.creeps.add(Creep {
                 pos: to_creep_position(self.state.creep_spawn, self.state.cell_length),
-                health: 3,
-                max_health: 10,
+                health: 34.0,
+                max_health: 34.0,
                 walking: WalkingProgress {
                     current_goal: 0,
                     steps_taken: 0,
@@ -287,11 +287,10 @@ impl Game {
             let d = distance(target_creep.pos, particle.pos);
             if d < 5.0 {
                 particles_to_remove.push(particle_item.item_ref);
-                if target_creep.health == 1 {
+                target_creep.health -= particle.damage;
+                if target_creep.health <= 0.0 {
                     self.state.creeps.remove(particle.target.clone());
                     self.state.gold += 1; // todo: gold per killed creep depending on level?
-                } else {
-                    target_creep.health -= 1;
                 }
             } else {
                 let dx = target_creep.pos.x - particle.pos.x;

--- a/src/recycled_list.rs
+++ b/src/recycled_list.rs
@@ -7,6 +7,12 @@ pub struct RecycledListRef {
     index: usize,
 }
 
+impl RecycledListRef {
+    pub fn null_ref() -> Self {
+        RecycledListRef { id: 0, index: 0 }
+    }
+}
+
 #[derive(Clone)]
 pub struct RecycledListItem<T> {
     pub item_ref: RecycledListRef,
@@ -29,7 +35,28 @@ impl<T> RecycledList<T> {
         }
     }
 
+    pub fn get(&self, item_ref: RecycledListRef) -> Option<&T> {
+        if item_ref.id == 0 {
+            return None;
+        }
+
+        let item = self.items.get(item_ref.index);
+        match item {
+            Some(c) => {
+                if c.item_ref.id == item_ref.id {
+                    return Some(&c.data);
+                }
+                None
+            }
+            _ => None,
+        }
+    }
+
     pub fn get_mut(&mut self, item_ref: RecycledListRef) -> Option<&mut T> {
+        if item_ref.id == 0 {
+            return None;
+        }
+
         let item = self.items.get_mut(item_ref.index);
         match item {
             Some(c) => {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -75,3 +75,9 @@ pub fn set_panic_hook() {
     #[cfg(feature = "console_error_panic_hook")]
     console_error_panic_hook::set_once();
 }
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_namespace = console)]
+    pub fn log(s: &str);
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -27,6 +27,17 @@ impl ops::Add<FloatPosition> for FloatPosition {
     }
 }
 
+impl ops::Sub<FloatPosition> for FloatPosition {
+    type Output = FloatPosition;
+
+    fn sub(self, rhs: FloatPosition) -> FloatPosition {
+        FloatPosition {
+            x: self.x - rhs.x,
+            y: self.y - rhs.y,
+        }
+    }
+}
+
 impl ops::Mul<f32> for FloatPosition {
     type Output = FloatPosition;
 


### PR DESCRIPTION
@PaulXiCao What is your opintion about this change? 

In the main update_state we just iterate over turrets, creeps, particles, and other entities. Then, the entities handle their own changes. To achieve that we need to have finer grained Rust burrow checking. We cannot just give the whole state to the turret to update, because we already burrow the turret List in the loop. So I moved the turret list out of the main state into the game, which allows the Turret to change everything inside the State, except the turret list.
